### PR TITLE
Fix crossbar works with numbres with "+" prefix

### DIFF
--- a/applications/crossbar/src/cb_context.erl
+++ b/applications/crossbar/src/cb_context.erl
@@ -375,7 +375,7 @@ path_token(Token) ->
 
 -spec path_tokens(context()) -> kz_term:ne_binaries().
 path_tokens(#cb_context{raw_path=Path}) ->
-    [path_token(kz_util:uri_decode(Token))
+    [path_token(Token)
      || Token <- binary:split(Path, <<"/">>, ['global', 'trim'])
     ].
 


### PR DESCRIPTION
Crossbar stopped working with numbers starting with "+". Double url decoding leads to this error in cb_context:path_tokens (see example):

`1> kz_util:uri_decode(<<"%2b79130001001">>).`
`<<"+79130001001">>`
`2> kz_util:uri_decode(kz_util:uri_decode(<<"%2b79130001001">>)).`
`<<" 79130001001">>`

the problem lies in the:
`3> http_uri:decode(<<"%2b79130001001">>).   `              
`<<"+79130001001">>`
`4> http_uri:decode(http_uri:decode(<<"%2b79130001001">>)).`
`<<" 79130001001">>`