### PR TITLE
Adding script to keep OTF branches synced with 2600hz

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,3 +119,46 @@ jobs:
         path: /tmp/circleci-artifacts
     - store_artifacts:
         path: /tmp/circleci-test-results
+
+  upstream_sync_master:
+    working_directory: ~/2600hz/kazoo
+    docker:
+      - image: circleci/python:3.6.5-jessie
+    steps:
+      - checkout
+      - run: ./scripts/sync-upstream-git.sh master
+
+  upstream_sync_41:
+    working_directory: ~/2600hz/kazoo
+    docker:
+      - image: circleci/python:3.6.5-jessie
+    steps:
+      - checkout
+      - run: ./scripts/sync-upstream-git.sh 4.1
+
+  upstream_sync_42:
+    working_directory: ~/2600hz/kazoo
+    docker:
+      - image: circleci/python:3.6.5-jessie
+    steps:
+      - checkout
+      - run: ./scripts/sync-upstream-git.sh 4.2
+
+workflows:
+  version: 2
+  commit:
+    jobs:
+      - build
+
+  nightly:
+    jobs:
+      - upstream_sync_master
+      - upstream_sync_41
+      - upstream_sync_42
+    triggers:
+      - schedule:
+          cron: 0 * * * *
+          filters:
+            branches:
+              only:
+                - otf-master

--- a/scripts/sync-upstream-git.sh
+++ b/scripts/sync-upstream-git.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+
+# Environment Variable Requirements:
+# - SSHKEY: A base64 encoded private SSH key that has its public key added to the repo
+# - GITHUB_ACCOUNT: Account name to use when creating PR requests
+# - GITHUB_TOKEN: Personal access token for the GITHUB_ACCOUNT
+
+set -e
+
+IFS=$'\n'
+
+update_branch() {
+    echo "Updating $1 branch..."
+    if [[ "$1" == "master" ]]; then
+        git checkout $1
+    else
+        git checkout -b $1 origin/$1
+    fi
+
+    git reset --hard $1
+    git merge upstream/$1 --no-edit
+    git push origin $1
+}
+
+setup_ssh() {
+    echo "Adding SSH key..."
+    echo $SSHKEY | base64 --decode > ~/.ssh/SSHKEY
+    chmod 400 ~/.ssh/SSHKEY
+    ssh-add -D
+    ssh-add ~/.ssh/SSHKEY
+}
+
+setup_git() {
+    echo "Setting up git config..."
+    git config --global user.email "derp@opentelecom.foundation"
+    git config --global user.name "OTF Git Syncaroo"
+
+    echo "Adding upstream..."
+    git remote add upstream https://github.com/2600hz/kazoo.git
+
+    echo "Fetching from upstream..."
+    git fetch upstream
+}
+
+cleanup() {
+    # Doing this for debug purposes, if we need to debug the script
+    # then we need to be back on the otf branch as that is the only
+    # place the script exists.
+    git checkout otf-master
+    git reset --hard otf-master
+}
+
+generate_pr_post_body() {
+    cat <<EOF
+{
+    "title": "Upstream merge: $1",
+    "body": "Automated daily PR. Deal with this ASAP please! :D",
+    "head": "$2",
+    "base": "otf-$1"
+}
+EOF
+}
+
+pr_upstream() {
+    PRS=$(curl --silent -X GET "https://api.github.com/repos/$CIRCLE_PROJECT_USERNAME/kazoo/pulls")
+    COUNT=$(echo $PRS | jq '. | length')
+    DATE=`date +%Y-%m-%d`
+    BRANCH="upstream-sync-$1-$DATE"
+
+    if [ "$COUNT" != "0" ]
+    then
+        for prtitle in $(echo "$PRS" | jq -r '.[].title'); do
+            if [ "$prtitle" == "Upstream merge: $1" ]
+            then
+                echo "Found existing PR for this branch ($1), skipping the creation of a new one."
+                return
+            fi
+        done
+    fi
+
+    git checkout origin/$1
+    git reset --hard origin/$1
+    git fetch
+    git checkout -b $BRANCH
+    git push -u origin $BRANCH
+
+    curl --silent \
+        -u $GITHUB_ACCOUNT:$GITHUB_TOKEN \
+        -H "Content-Type: application/json" \
+        -X POST "https://api.github.com/repos/$CIRCLE_PROJECT_USERNAME/kazoo/pulls" \
+        --data "$(generate_pr_post_body $1 $BRANCH)"
+}
+
+# Quick test to see if we should run this script. If you're
+# trying to debug/run this script in your repo add your
+# username for circleci to this section.
+if [[ "$CIRCLE_PROJECT_USERNAME" =~ ^(regner|OpenTelecom)$ ]]; then
+    echo "$CIRCLE_PROJECT_USERNAME is in the list of repos to run against..."
+else
+    echo "$CIRCLE_PROJECT_USERNAME is not in the list of repos to run against. Aborting."
+    exit 0
+fi
+
+setup_ssh
+setup_git
+
+update_branch $1
+pr_upstream $1
+
+cleanup


### PR DESCRIPTION
This script is meant to do a couple of things every night:
- Merge upstream (2600hz) changes into master, 4.1, and 4.2 and push those changes
- Create a new branch from master, 4.1, and 4.2 and create a PR from that new branch into the OTF version of that branch
- Don't do step 2 if there is an existing PR

A new GitHub account needs to be created to act as the person doing the syncing.

Once the account is setup the CircleCI project needs to be configured and the following environment variables need to be configured:
- SSHKEY: A base64 encoded private SSH key that has its public key added to the repo
- GITHUB_ACCOUNT: Account name to use when creating PR requests
- GITHUB_TOKEN: Personal access token for the GITHUB_ACCOUNT

Known issues:
- The new branch gets pushed even if there are no changes between it and the OTF version of the branch. Need to find some way to identify if there actually are changes between two branches.