### PR TITLE
Add support for remove Caller-ID-Name from SIP From Header

### DIFF
--- a/applications/ecallmgr/src/ecallmgr_util.erl
+++ b/applications/ecallmgr/src/ecallmgr_util.erl
@@ -646,6 +646,8 @@ get_fs_key_and_value(_, _, _) -> 'skip'.
 %% @end
 %%------------------------------------------------------------------------------
 -spec maybe_sanitize_fs_value(kz_term:text(), kz_term:text()) -> binary().
+maybe_sanitize_fs_value(<<"Outbound-Caller-ID-Name">>, <<"_undef_">>) ->
+    <<"_undef_">>;
 maybe_sanitize_fs_value(<<"Outbound-Caller-ID-Name">>, Val) ->
     re:replace(Val, <<"[^a-zA-Z0-9-\s]">>, <<>>, ['global', {'return', 'binary'}]);
 maybe_sanitize_fs_value(<<"Outbound-Callee-ID-Name">>, Val) ->

--- a/core/kazoo_endpoint/doc/formatters.md
+++ b/core/kazoo_endpoint/doc/formatters.md
@@ -31,7 +31,7 @@ For outbound (to the carrier) formatters, you can see the fields available by lo
 
 Inbound (from the carrier) fields are found in the [kapi_route request schema](https://github.com/2600hz/kazoo/blob/master/applications/crossbar/priv/couchdb/schemas/kapi_route.req.json).
 
-In both of the above cases the request, to and from fields are tracked outside of the mentioned schemas. 
+In both of the above cases the request, to and from fields are tracked outside of the mentioned schemas.
 
 #### Devices, users, accounts
 
@@ -188,3 +188,17 @@ The caller ID presented to the device can be altered by creating a formatter obj
 ```
 
 This would match caller id numbers that end with 10 digits and capture them as the value to be used.
+
+### Remove Caller-ID-Name from SIP From Header
+
+To remove Caller-ID-Name from SIP From Header for outbound calls you sould set static value ['\_undef_'](https://freeswitch.org/jira/browse/FS-942) for the 'outbound_caller_id_name' formatter:
+
+```json
+"formatters": {
+    "outbound_caller_id_name": [
+        {
+            "value": "_undef_"
+        }
+    ]
+}
+```


### PR DESCRIPTION
Some times it is required to remove Caller-ID-Name from SIP Header. Attempt to remove this field with stripping in formatter 'Outbound-Caller-ID-Name' was fail because freeswitch repair Caller-ID-Name from effective_caller_id_name.
To fix that problem we sould set caller_id_name as '\_undef_' according with ['Remove Caller ID Name from SIP From Header'](https://freeswitch.org/jira/browse/FS-942).